### PR TITLE
Port pqm3 kyberm3.S to ARM Compiler v5 armasm syntax

### DIFF
--- a/ASM/fastinvnttm3.s
+++ b/ASM/fastinvnttm3.s
@@ -1,0 +1,280 @@
+; -----------------------------------------------------------------------------
+; fastinvnttm3.s
+;
+; Port of pqm3 crypto_kem/kyber768/m3/fastinvnttm3.S (GNU `as`, Thumb-2 UAL) to
+; ARM Compiler v5.06 `armasm` syntax, targeting an SC300 (Cortex-M3 / ARMv7-M)
+; core.  Implements the inverse number-theoretic transform used by Kyber-768.
+;
+; Register aliases from the original .req table (inline-expanded in the body):
+;   r0  = poly          r1  = twiddle_ptr
+;   r2  = poly0         r3  = poly1   r4 = poly2   r5 = poly3
+;   r6  = poly4         r7  = poly5   r8 = poly6   r9 = poly7
+;   r10 = twiddle / montconst / barrettconst
+;   r11 = q             r12 = tmp     r14 = qinv
+;
+; NOTE on signed_barrettm3:
+; The GNU source adds the literal `#67108864` (= 0x04000000 = 2^26) inside the
+; macro.  That immediate is NOT representable in the Thumb-2 ADD imm12
+; modified-immediate encoding; GNU `as` silently expands it into a MOVW/MOVT
+; sequence plus an ADD, but armasm v5.06 rejects the literal outright.  All
+; registers in invntt_fast_m3 are already bound, so we cannot allocate an
+; extra scratch at the call sites.  The fix is to rebuild 0x04000000 from
+; MOVW/MOVT into $barrettconst *inside* the macro (after the initial MUL,
+; at which point $barrettconst is dead for the rest of this invocation) and
+; to move the `MOVW #25218 / SXTH` reseed inside the macro too so every
+; invocation starts from a clean barrettconst.  The computed value is
+; identical to the GNU version; only the instruction stream differs.
+;
+; Source upstream: https://github.com/mupq/pqm3  (public-domain / CC0)
+; -----------------------------------------------------------------------------
+
+        PRESERVE8
+        THUMB
+
+; Global assembler variable used by the WHILE/WEND unroll that replaces the
+; original `.rept 4` + `.set k` construct in LAYER 2+3+4.
+        GBLA    k
+
+        AREA    |.text|, CODE, READONLY
+
+; -----------------------------------------------------------------------------
+; Macro: montgomerym3
+;   Signed Montgomery reduction of a 32-bit value.
+; -----------------------------------------------------------------------------
+        MACRO
+        montgomerym3 $q, $qinv, $a, $tmp
+        mul.w   $tmp, $a, $qinv
+        sxth.w  $tmp, $tmp
+        mla.w   $a, $tmp, $q, $a
+        asr.w   $a, $a, #16
+        MEND
+
+; -----------------------------------------------------------------------------
+; Macro: gsbutterflym3
+;   Gentleman-Sande butterfly with Montgomery-reduced twiddle.
+; -----------------------------------------------------------------------------
+        MACRO
+        gsbutterflym3 $poly0, $poly1, $twiddle, $tmp, $q, $qinv
+        sub.w   $tmp, $poly0, $poly1
+        add.w   $poly0, $poly0, $poly1
+
+        mul.w   $poly1, $tmp, $twiddle
+        montgomerym3 $q, $qinv, $poly1, $tmp
+        MEND
+
+; -----------------------------------------------------------------------------
+; Macro: fqmulprecompm3
+;   Multiply $a by a pre-Montgomery-scaled twiddle and reduce.
+; -----------------------------------------------------------------------------
+        MACRO
+        fqmulprecompm3 $a, $twiddle, $tmp, $q, $qinv
+        mul.w   $a, $a, $twiddle
+        montgomerym3 $q, $qinv, $a, $tmp
+        MEND
+
+; -----------------------------------------------------------------------------
+; Macro: signed_barrettm3
+;   Signed Barrett reduction.  See file header for why the reseed of
+;   $barrettconst and the MOVW/MOVT rebuild of 2^26 live inside the macro.
+; -----------------------------------------------------------------------------
+        MACRO
+        signed_barrettm3 $a, $q, $tmp, $barrettconst
+        ; Reload Barrett constant (original comment: -40318, encoded as the
+        ; 16-bit value 25218 followed by SXTH).
+        movw    $barrettconst, #25218
+        sxth    $barrettconst, $barrettconst
+        mul.w   $tmp, $a, $barrettconst
+        ; Add 2^26 by rebuilding the constant in $barrettconst.  $barrettconst
+        ; is dead after the MUL above; we will reload it on the next macro
+        ; invocation.
+        movw    $barrettconst, #0x0000
+        movt    $barrettconst, #0x0400
+        add.w   $tmp, $tmp, $barrettconst
+        asr.w   $tmp, $tmp, #27
+        mla.w   $a, $tmp, $q, $a
+        MEND
+
+; =============================================================================
+; invntt_fast_m3(int16_t *poly, const int16_t *twiddles)
+;   r0 = poly, r1 = twiddle_ptr
+; =============================================================================
+        ALIGN   4
+        EXPORT  invntt_fast_m3
+invntt_fast_m3 PROC
+        push.w  {r4-r11, r14}
+
+        movw    r11, #3329          ; q
+        movw    r14, #3327          ; qinv
+
+        ; ### LAYER 1 (skip layer 0)
+        movw    r12, #32            ; tmp = outer loop counter
+invntt_L1
+        push.w  {r12}
+
+        ldrsh.w r2, [r0, #0]
+        ldrsh.w r3, [r0, #2]
+        ldrsh.w r4, [r0, #4]
+        ldrsh.w r5, [r0, #6]
+        ldrsh.w r6, [r0, #8]
+        ldrsh.w r7, [r0, #10]
+        ldrsh.w r8, [r0, #12]
+        ldrsh.w r9, [r0, #14]
+
+        ldrsh.w r10, [r1], #2
+        gsbutterflym3 r2, r4, r10, r12, r11, r14
+        gsbutterflym3 r3, r5, r10, r12, r11, r14
+
+        ldrsh.w r10, [r1], #2
+        gsbutterflym3 r6, r8, r10, r12, r11, r14
+        gsbutterflym3 r7, r9, r10, r12, r11, r14
+
+        ; signed Barrett reduction of the four layer-1-mixed coefficients.
+        ; The seed/rebuild of $barrettconst is encapsulated in the macro.
+        signed_barrettm3 r2, r11, r12, r10
+        signed_barrettm3 r3, r11, r12, r10
+        signed_barrettm3 r6, r11, r12, r10
+        signed_barrettm3 r7, r11, r12, r10
+
+        strh.w  r3, [r0, #2]
+        strh.w  r4, [r0, #4]
+        strh.w  r5, [r0, #6]
+        strh.w  r6, [r0, #8]
+        strh.w  r7, [r0, #10]
+        strh.w  r8, [r0, #12]
+        strh.w  r9, [r0, #14]
+        strh.w  r2, [r0], #16
+
+        pop.w   {r12}
+        subs.w  r12, #1
+        bne.w   invntt_L1
+
+        sub.w   r0, #512
+
+        ; ### LAYER 2+3+4
+        movw    r12, #8
+invntt_L2
+        push.w  {r12}
+
+k       SETA    1
+        WHILE   k <= 4
+        ldrsh.w r2, [r0, #0]
+        ldrsh.w r3, [r0, #8]
+        ldrsh.w r4, [r0, #16]
+        ldrsh.w r5, [r0, #24]
+        ldrsh.w r6, [r0, #32]
+        ldrsh.w r7, [r0, #40]
+        ldrsh.w r8, [r0, #48]
+        ldrsh.w r9, [r0, #56]
+
+        ldrsh.w r10, [r1, #0]
+        gsbutterflym3 r2, r3, r10, r12, r11, r14
+        ldrsh.w r10, [r1, #2]
+        gsbutterflym3 r4, r5, r10, r12, r11, r14
+        ldrsh.w r10, [r1, #4]
+        gsbutterflym3 r6, r7, r10, r12, r11, r14
+        ldrsh.w r10, [r1, #6]
+        gsbutterflym3 r8, r9, r10, r12, r11, r14
+
+        ldrsh.w r10, [r1, #8]
+        gsbutterflym3 r2, r4, r10, r12, r11, r14
+        gsbutterflym3 r3, r5, r10, r12, r11, r14
+
+        ldrsh.w r10, [r1, #10]
+        gsbutterflym3 r6, r8, r10, r12, r11, r14
+        gsbutterflym3 r7, r9, r10, r12, r11, r14
+
+        ldrsh.w r10, [r1, #12]
+        gsbutterflym3 r2, r6, r10, r12, r11, r14
+        gsbutterflym3 r3, r7, r10, r12, r11, r14
+        gsbutterflym3 r4, r8, r10, r12, r11, r14
+        gsbutterflym3 r5, r9, r10, r12, r11, r14
+
+        ; Montgomery pre-multiply by 2285 on the first four outputs
+        ; (original preserved the commented-out signed_barrettm3 alternative).
+        movw    r10, #2285
+        fqmulprecompm3 r2, r10, r12, r11, r14
+        fqmulprecompm3 r3, r10, r12, r11, r14
+        fqmulprecompm3 r4, r10, r12, r11, r14
+        fqmulprecompm3 r5, r10, r12, r11, r14
+
+        strh.w  r3, [r0, #8]
+        strh.w  r4, [r0, #16]
+        strh.w  r5, [r0, #24]
+        strh.w  r6, [r0, #32]
+        strh.w  r7, [r0, #40]
+        strh.w  r8, [r0, #48]
+        strh.w  r9, [r0, #56]
+        IF k != 4
+        strh.w  r2, [r0], #2
+        ELSE
+        strh.w  r2, [r0], #58
+        ENDIF
+k       SETA    k + 1
+        WEND
+        add.w   r1, #14
+
+        pop.w   {r12}
+        subs.w  r12, #1
+        bne.w   invntt_L2
+
+        sub.w   r0, #512
+
+        ; ### LAYER 5+6+7
+        movw    r12, #32
+invntt_L3
+        push.w  {r12}
+
+        ldrsh.w r2, [r0, #0]
+        ldrsh.w r3, [r0, #64]
+        ldrsh.w r4, [r0, #128]
+        ldrsh.w r5, [r0, #192]
+        ldrsh.w r6, [r0, #256]
+        ldrsh.w r7, [r0, #320]
+        ldrsh.w r8, [r0, #384]
+        ldrsh.w r9, [r0, #448]
+
+        ldrsh.w r10, [r1]
+        gsbutterflym3 r2, r3, r10, r12, r11, r14
+        ldrsh.w r10, [r1, #2]
+        gsbutterflym3 r4, r5, r10, r12, r11, r14
+        ldrsh.w r10, [r1, #4]
+        gsbutterflym3 r6, r7, r10, r12, r11, r14
+        ldrsh.w r10, [r1, #6]
+        gsbutterflym3 r8, r9, r10, r12, r11, r14
+
+        ldrsh.w r10, [r1, #8]
+        gsbutterflym3 r2, r4, r10, r12, r11, r14
+        gsbutterflym3 r3, r5, r10, r12, r11, r14
+        ldrsh.w r10, [r1, #10]
+        gsbutterflym3 r6, r8, r10, r12, r11, r14
+        gsbutterflym3 r7, r9, r10, r12, r11, r14
+
+        ldrsh.w r10, [r1, #12]
+        gsbutterflym3 r2, r6, r10, r12, r11, r14
+        gsbutterflym3 r3, r7, r10, r12, r11, r14
+        gsbutterflym3 r4, r8, r10, r12, r11, r14
+        gsbutterflym3 r5, r9, r10, r12, r11, r14
+
+        ldrsh.w r10, [r1, #14]
+        fqmulprecompm3 r2, r10, r12, r11, r14
+        fqmulprecompm3 r3, r10, r12, r11, r14
+        fqmulprecompm3 r4, r10, r12, r11, r14
+        fqmulprecompm3 r5, r10, r12, r11, r14
+
+        strh.w  r3, [r0, #64]
+        strh.w  r4, [r0, #128]
+        strh.w  r5, [r0, #192]
+        strh.w  r6, [r0, #256]
+        strh.w  r7, [r0, #320]
+        strh.w  r8, [r0, #384]
+        strh.w  r9, [r0, #448]
+        strh.w  r2, [r0], #2
+
+        pop.w   {r12}
+        subs.w  r12, #1
+        bne.w   invntt_L3
+
+        pop.w   {r4-r11, pc}
+        ENDP
+
+        END

--- a/ASM/fastnttm3.s
+++ b/ASM/fastnttm3.s
@@ -1,0 +1,231 @@
+; -----------------------------------------------------------------------------
+; fastnttm3.s
+;
+; Port of pqm3 crypto_kem/kyber768/m3/fastnttm3.S (GNU `as`, Thumb-2 UAL) to
+; ARM Compiler v5.06 `armasm` syntax, targeting an SC300 (Cortex-M3 / ARMv7-M)
+; core.  Implements the forward number-theoretic transform used by Kyber-768.
+;
+; Register aliases from the original .req table (inline-expanded in the body):
+;   r0  = poly          r1  = twiddle_ptr
+;   r2  = poly0         r3  = poly1   r4 = poly2   r5 = poly3
+;   r6  = poly4         r7  = poly5   r8 = poly6   r9 = poly7
+;   r10 = twiddle / barrettconst      r11 = qinv    r12 = q    r14 = tmp
+;
+; Source upstream: https://github.com/mupq/pqm3  (public-domain / CC0)
+; -----------------------------------------------------------------------------
+
+        PRESERVE8
+        THUMB
+
+; Global assembler variable used by the WHILE/WEND unroll that replaces the
+; original `.rept 4` + `.set k` construct in LAYER 4+3+2.
+        GBLA    k
+
+barrett_constant EQU 20159
+
+        AREA    |.text|, CODE, READONLY
+
+; -----------------------------------------------------------------------------
+; Macro: butterflym3
+;   Cooley-Tukey butterfly with Montgomery-reduced twiddle.
+;   $a0 : poly[i]   (in/out)
+;   $a1 : poly[j]   (in/out)
+;   $twiddle : twiddle factor
+;   $q   : modulus q
+;   $qinv: q^{-1} mod 2^16
+;   $tmp : scratch
+; -----------------------------------------------------------------------------
+        MACRO
+        butterflym3 $a0, $a1, $twiddle, $q, $qinv, $tmp
+        mul.w   $a1, $a1, $twiddle
+        mul.w   $tmp, $a1, $qinv
+        sxth.w  $tmp, $tmp
+        mla.w   $tmp, $tmp, $q, $a1
+        sub.w   $a1, $a0, $tmp, asr #16
+        add.w   $a0, $a0, $tmp, asr #16
+        MEND
+
+; -----------------------------------------------------------------------------
+; Macro: barrettm3
+;   Unsigned Barrett reduction.
+; -----------------------------------------------------------------------------
+        MACRO
+        barrettm3 $a, $tmp, $q, $barrettconst
+        mul.w   $tmp, $a, $barrettconst
+        asr.w   $tmp, $tmp, #26
+        mul.w   $tmp, $tmp, $q
+        sub.w   $a, $a, $tmp
+        MEND
+
+; =============================================================================
+; ntt_fast_m3(int16_t *poly, const int16_t *twiddles)
+;   r0 = poly, r1 = twiddle_ptr
+; =============================================================================
+        ALIGN   4
+        EXPORT  ntt_fast_m3
+ntt_fast_m3 PROC
+        push.w  {r4-r11, r14}
+
+        movw    r11, #3327          ; qinv
+        movw    r12, #3329          ; q
+
+        ; ### LAYER 7+6+5
+        movw    r14, #32            ; tmp = outer loop counter
+ntt_L1
+        push.w  {r14}
+
+        ldrsh.w r2, [r0]
+        ldrsh.w r3, [r0, #64]
+        ldrsh.w r4, [r0, #128]
+        ldrsh.w r5, [r0, #192]
+        ldrsh.w r6, [r0, #256]
+        ldrsh.w r7, [r0, #320]
+        ldrsh.w r8, [r0, #384]
+        ldrsh.w r9, [r0, #448]
+
+        ldrsh.w r10, [r1]
+        butterflym3 r2, r6, r10, r12, r11, r14
+        butterflym3 r3, r7, r10, r12, r11, r14
+        butterflym3 r4, r8, r10, r12, r11, r14
+        butterflym3 r5, r9, r10, r12, r11, r14
+
+        ldrsh.w r10, [r1, #2]
+        butterflym3 r2, r4, r10, r12, r11, r14
+        butterflym3 r3, r5, r10, r12, r11, r14
+        ldrsh.w r10, [r1, #4]
+        butterflym3 r6, r8, r10, r12, r11, r14
+        butterflym3 r7, r9, r10, r12, r11, r14
+
+        ldrsh.w r10, [r1, #6]
+        butterflym3 r2, r3, r10, r12, r11, r14
+        ldrsh.w r10, [r1, #8]
+        butterflym3 r4, r5, r10, r12, r11, r14
+        ldrsh.w r10, [r1, #10]
+        butterflym3 r6, r7, r10, r12, r11, r14
+        ldrsh.w r10, [r1, #12]
+        butterflym3 r8, r9, r10, r12, r11, r14
+
+        strh.w  r3, [r0, #64]
+        strh.w  r4, [r0, #128]
+        strh.w  r5, [r0, #192]
+        strh.w  r6, [r0, #256]
+        strh.w  r7, [r0, #320]
+        strh.w  r8, [r0, #384]
+        strh.w  r9, [r0, #448]
+        strh.w  r2, [r0], #2
+
+        pop.w   {r14}
+        subs.w  r14, #1
+        bne.w   ntt_L1
+
+        sub.w   r0, #64
+        add.w   r1, #14
+
+        ; ### LAYER 4+3+2
+        movw    r14, #8
+ntt_L2
+        push.w  {r14}
+
+k       SETA    1
+        WHILE   k <= 4
+        ldrsh.w r2, [r0]
+        ldrsh.w r3, [r0, #8]
+        ldrsh.w r4, [r0, #16]
+        ldrsh.w r5, [r0, #24]
+        ldrsh.w r6, [r0, #32]
+        ldrsh.w r7, [r0, #40]
+        ldrsh.w r8, [r0, #48]
+        ldrsh.w r9, [r0, #56]
+
+        ldrsh.w r10, [r1]
+        butterflym3 r2, r6, r10, r12, r11, r14
+        butterflym3 r3, r7, r10, r12, r11, r14
+        butterflym3 r4, r8, r10, r12, r11, r14
+        butterflym3 r5, r9, r10, r12, r11, r14
+
+        ldrsh.w r10, [r1, #2]
+        butterflym3 r2, r4, r10, r12, r11, r14
+        butterflym3 r3, r5, r10, r12, r11, r14
+        ldrsh.w r10, [r1, #4]
+        butterflym3 r6, r8, r10, r12, r11, r14
+        butterflym3 r7, r9, r10, r12, r11, r14
+
+        ldrsh.w r10, [r1, #6]
+        butterflym3 r2, r3, r10, r12, r11, r14
+        ldrsh.w r10, [r1, #8]
+        butterflym3 r4, r5, r10, r12, r11, r14
+        ldrsh.w r10, [r1, #10]
+        butterflym3 r6, r7, r10, r12, r11, r14
+        ldrsh.w r10, [r1, #12]
+        butterflym3 r8, r9, r10, r12, r11, r14
+
+        strh.w  r3, [r0, #8]
+        strh.w  r4, [r0, #16]
+        strh.w  r5, [r0, #24]
+        strh.w  r6, [r0, #32]
+        strh.w  r7, [r0, #40]
+        strh.w  r8, [r0, #48]
+        strh.w  r9, [r0, #56]
+        IF k != 4
+        strh.w  r2, [r0], #2
+        ELSE
+        strh.w  r2, [r0], #58
+        ENDIF
+k       SETA    k + 1
+        WEND
+        add.w   r1, #14
+
+        pop.w   {r14}
+        subs.w  r14, #1
+        bne.w   ntt_L2
+
+        sub.w   r0, #512
+
+        ; ### LAYER 1 (skip layer 0)
+        movw    r14, #32
+ntt_L4
+        push.w  {r14}
+
+        ldrsh.w r2, [r0]
+        ldrsh.w r3, [r0, #2]
+        ldrsh.w r4, [r0, #4]
+        ldrsh.w r5, [r0, #6]
+        ldrsh.w r6, [r0, #8]
+        ldrsh.w r7, [r0, #10]
+        ldrsh.w r8, [r0, #12]
+        ldrsh.w r9, [r0, #14]
+
+        ldrsh.w r10, [r1], #2
+        butterflym3 r2, r4, r10, r12, r11, r14
+        butterflym3 r3, r5, r10, r12, r11, r14
+        ldrsh.w r10, [r1], #2
+        butterflym3 r6, r8, r10, r12, r11, r14
+        butterflym3 r7, r9, r10, r12, r11, r14
+
+        movw    r10, #barrett_constant
+        barrettm3 r2, r14, r12, r10
+        barrettm3 r3, r14, r12, r10
+        barrettm3 r4, r14, r12, r10
+        barrettm3 r5, r14, r12, r10
+        barrettm3 r6, r14, r12, r10
+        barrettm3 r7, r14, r12, r10
+        barrettm3 r8, r14, r12, r10
+        barrettm3 r9, r14, r12, r10
+
+        strh.w  r3, [r0, #2]
+        strh.w  r4, [r0, #4]
+        strh.w  r5, [r0, #6]
+        strh.w  r6, [r0, #8]
+        strh.w  r7, [r0, #10]
+        strh.w  r8, [r0, #12]
+        strh.w  r9, [r0, #14]
+        strh.w  r2, [r0], #16
+
+        pop.w   {r14}
+        subs.w  r14, #1
+        bne.w   ntt_L4
+
+        pop.w   {r4-r11, pc}
+        ENDP
+
+        END

--- a/ASM/kyberm3.s
+++ b/ASM/kyberm3.s
@@ -1,0 +1,505 @@
+; -----------------------------------------------------------------------------
+; kyberm3.s
+;
+; Port of pqm3 crypto_kem/kyber768/m3/kyberm3.S (GNU `as`, Thumb-2 UAL) to
+; ARM Compiler v5.06 `armasm` syntax, targeting an SC300 (Cortex-M3 / ARMv7-M)
+; core.  Instruction set and semantics are unchanged; only directives, macro
+; syntax, label style and register-alias handling have been converted.
+;
+; Source upstream: https://github.com/mupq/pqm3  (public-domain / CC0)
+; -----------------------------------------------------------------------------
+
+        PRESERVE8
+        THUMB
+
+        AREA    |.text|, CODE, READONLY
+
+; -----------------------------------------------------------------------------
+; Macro: barrettm3
+;   Unsigned Barrett reduction.
+;   $a  : value to reduce (in/out)
+;   $tmp: scratch register
+;   $q  : modulus q (in)
+;   $barrettconst : Barrett multiplier (in)
+; -----------------------------------------------------------------------------
+        MACRO
+        barrettm3 $a, $tmp, $q, $barrettconst
+        mul.w   $tmp, $a, $barrettconst
+        asr.w   $tmp, $tmp, #26
+        mul.w   $tmp, $tmp, $q
+        sub.w   $a, $a, $tmp
+        MEND
+
+; -----------------------------------------------------------------------------
+; Macro: montgomerym3
+;   Signed Montgomery reduction of a 32-bit value.
+;   $q   : modulus q (in)
+;   $qinv: q^{-1} mod 2^16 (in)
+;   $a   : value to reduce (in/out)
+;   $tmp : scratch register
+; -----------------------------------------------------------------------------
+        MACRO
+        montgomerym3 $q, $qinv, $a, $tmp
+        mul.w   $tmp, $a, $qinv
+        sxth.w  $tmp, $tmp
+        mla.w   $a, $tmp, $q, $a
+        asr.w   $a, $a, #16
+        MEND
+
+; =============================================================================
+; pointwise_sub_m3 : polynomial subtraction
+; r0 = result ptr, r1 = a ptr, r2 = b ptr (256 int16 each)
+; =============================================================================
+        ALIGN   4
+        EXPORT  pointwise_sub_m3
+pointwise_sub_m3 PROC
+        push.w  {r4-r11, lr}
+
+        movw    r14, #51
+psub_L1
+        ldrsh.w r4, [r1, #2]
+        ldrsh.w r5, [r1, #4]
+        ldrsh.w r6, [r1, #6]
+        ldrsh.w r7, [r1, #8]
+        ldrsh.w r3, [r1], #10
+        ldrsh.w r9, [r2, #2]
+        ldrsh.w r10, [r2, #4]
+        ldrsh.w r11, [r2, #6]
+        ldrsh.w r12, [r2, #8]
+        ldrsh.w r8, [r2], #10
+
+        sub.w   r3, r3, r8
+        sub.w   r4, r4, r9
+        sub.w   r5, r5, r10
+        sub.w   r6, r6, r11
+        sub.w   r7, r7, r12
+
+        strh.w  r4, [r0, #2]
+        strh.w  r5, [r0, #4]
+        strh.w  r6, [r0, #6]
+        strh.w  r7, [r0, #8]
+        strh.w  r3, [r0], #10
+        subs.w  r14, #1
+        bne.w   psub_L1
+
+        ldrsh.w r3, [r1]
+        ldrsh.w r4, [r2]
+        sub.w   r3, r3, r4
+        strh.w  r3, [r0]
+
+        pop.w   {r4-r11, pc}
+        ENDP
+
+; =============================================================================
+; pointwise_add_m3 : polynomial addition
+; r0 = result ptr, r1 = a ptr, r2 = b ptr (256 int16 each)
+; =============================================================================
+        ALIGN   4
+        EXPORT  pointwise_add_m3
+pointwise_add_m3 PROC
+        push.w  {r4-r11, lr}
+
+        movw    r14, #51
+padd_L1
+        ldrsh.w r4, [r1, #2]
+        ldrsh.w r5, [r1, #4]
+        ldrsh.w r6, [r1, #6]
+        ldrsh.w r7, [r1, #8]
+        ldrsh.w r3, [r1], #10
+        ldrsh.w r9, [r2, #2]
+        ldrsh.w r10, [r2, #4]
+        ldrsh.w r11, [r2, #6]
+        ldrsh.w r12, [r2, #8]
+        ldrsh.w r8, [r2], #10
+
+        add.w   r3, r3, r8
+        add.w   r4, r4, r9
+        add.w   r5, r5, r10
+        add.w   r6, r6, r11
+        add.w   r7, r7, r12
+
+        strh.w  r4, [r0, #2]
+        strh.w  r5, [r0, #4]
+        strh.w  r6, [r0, #6]
+        strh.w  r7, [r0, #8]
+        strh.w  r3, [r0], #10
+        subs.w  r14, #1
+        bne.w   padd_L1
+
+        ldrsh.w r3, [r1]
+        ldrsh.w r4, [r2]
+        add.w   r3, r3, r4
+        strh.w  r3, [r0]
+
+        pop.w   {r4-r11, pc}
+        ENDP
+
+; =============================================================================
+; asm_barrett_reduce_m3 : in-place Barrett reduction of 256 int16 coeffs
+; Register mapping (inline-expanded from original .req table):
+;   r0 = poly          r1..r8 = poly0..poly7          r14 = poly8
+;   r9 = loop          r10 = barrettconst             r11 = q
+;   r12 = tmp
+; =============================================================================
+        ALIGN   4
+        EXPORT  asm_barrett_reduce_m3
+asm_barrett_reduce_m3 PROC
+        push.w  {r4-r11, r14}
+
+        movw    r10, #20159         ; barrettconst
+        movw    r11, #3329          ; q
+
+        movw    r9, #28             ; loop
+barred_L1
+        ldrsh.w r1,  [r0, #0]
+        ldrsh.w r2,  [r0, #2]
+        ldrsh.w r3,  [r0, #4]
+        ldrsh.w r4,  [r0, #6]
+        ldrsh.w r5,  [r0, #8]
+        ldrsh.w r6,  [r0, #10]
+        ldrsh.w r7,  [r0, #12]
+        ldrsh.w r8,  [r0, #14]
+        ldrsh.w r14, [r0, #16]
+
+        barrettm3 r1,  r12, r11, r10
+        barrettm3 r2,  r12, r11, r10
+        barrettm3 r3,  r12, r11, r10
+        barrettm3 r4,  r12, r11, r10
+        barrettm3 r5,  r12, r11, r10
+        barrettm3 r6,  r12, r11, r10
+        barrettm3 r7,  r12, r11, r10
+        barrettm3 r8,  r12, r11, r10
+        barrettm3 r14, r12, r11, r10
+
+        strh.w  r2,  [r0, #2]
+        strh.w  r3,  [r0, #4]
+        strh.w  r4,  [r0, #6]
+        strh.w  r5,  [r0, #8]
+        strh.w  r6,  [r0, #10]
+        strh.w  r7,  [r0, #12]
+        strh.w  r8,  [r0, #14]
+        strh.w  r14, [r0, #16]
+        strh.w  r1,  [r0], #18
+        subs.w  r9, #1
+        bne.w   barred_L1
+
+        ; Tail: remaining 4 coefficients (28*9 + 4 = 256).
+        ldrsh.w r1, [r0, #0]
+        ldrsh.w r2, [r0, #2]
+        ldrsh.w r3, [r0, #4]
+        ldrsh.w r4, [r0, #6]
+        barrettm3 r1, r12, r11, r10
+        barrettm3 r2, r12, r11, r10
+        barrettm3 r3, r12, r11, r10
+        barrettm3 r4, r12, r11, r10
+        strh.w  r1, [r0, #0]
+        strh.w  r2, [r0, #2]
+        strh.w  r3, [r0, #4]
+        strh.w  r4, [r0, #6]
+
+        pop.w   {r4-r11, pc}
+        ENDP
+
+; =============================================================================
+; asm_frommont_m3 : convert 256 int16 coeffs out of Montgomery form
+; Register mapping:
+;   r0 = poly          r1..r8 = poly0..poly7
+;   r9 = loop          r10 = constant (1353)
+;   r11 = q            r12 = tmp          r14 = qinv
+; =============================================================================
+        ALIGN   4
+        EXPORT  asm_frommont_m3
+asm_frommont_m3 PROC
+        push.w  {r4-r11, r14}
+
+        movw    r11, #3329          ; q
+        movw    r14, #3327          ; qinv
+        movw    r10, #1353          ; constant
+
+        movw    r9, #32             ; loop
+frommont_L1
+        ldrsh.w r1, [r0, #0]
+        ldrsh.w r2, [r0, #2]
+        ldrsh.w r3, [r0, #4]
+        ldrsh.w r4, [r0, #6]
+        ldrsh.w r5, [r0, #8]
+        ldrsh.w r6, [r0, #10]
+        ldrsh.w r7, [r0, #12]
+        ldrsh.w r8, [r0, #14]
+
+        mul.w   r1, r1, r10
+        mul.w   r2, r2, r10
+        mul.w   r3, r3, r10
+        mul.w   r4, r4, r10
+        mul.w   r5, r5, r10
+        mul.w   r6, r6, r10
+        mul.w   r7, r7, r10
+        mul.w   r8, r8, r10
+        montgomerym3 r11, r14, r1, r12
+        montgomerym3 r11, r14, r2, r12
+        montgomerym3 r11, r14, r3, r12
+        montgomerym3 r11, r14, r4, r12
+        montgomerym3 r11, r14, r5, r12
+        montgomerym3 r11, r14, r6, r12
+        montgomerym3 r11, r14, r7, r12
+        montgomerym3 r11, r14, r8, r12
+
+        strh.w  r2, [r0, #2]
+        strh.w  r3, [r0, #4]
+        strh.w  r4, [r0, #6]
+        strh.w  r5, [r0, #8]
+        strh.w  r6, [r0, #10]
+        strh.w  r7, [r0, #12]
+        strh.w  r8, [r0, #14]
+        strh.w  r1, [r0], #16
+
+        subs.w  r9, #1
+        bne.w   frommont_L1
+
+        pop.w   {r4-r11, pc}
+        ENDP
+
+; =============================================================================
+; doublebasemul_asm_m3 : compute two 2-coeff base multiplications with zeta
+; Register mapping:
+;   r0=rptr r1=aptr r2=bptr r3=zeta
+;   r4=poly0 r5=poly2 r6=poly1 r7=poly3   (ordering preserved from source)
+;   r8=q r9=tmp r10=tmp2 r14=qinv
+; =============================================================================
+        ALIGN   4
+        EXPORT  doublebasemul_asm_m3
+doublebasemul_asm_m3 PROC
+        push.w  {r4-r11, lr}
+
+        movw    r8,  #3329          ; q
+        movw    r14, #3327          ; qinv
+
+        ldrsh.w r4, [r1, #0]        ; poly0
+        ldrsh.w r6, [r1, #2]        ; poly1
+        ldrsh.w r5, [r2, #0]        ; poly2
+        ldrsh.w r7, [r2, #2]        ; poly3
+
+        mul.w   r9, r6, r7
+        montgomerym3 r8, r14, r9, r10
+        mul.w   r9, r9, r3
+        mla.w   r9, r4, r5, r9
+        montgomerym3 r8, r14, r9, r10
+        strh.w  r9, [r0, #0]
+
+        mul.w   r9, r4, r7
+        mla.w   r9, r6, r5, r9
+        montgomerym3 r8, r14, r9, r10
+        strh.w  r9, [r0, #2]
+
+        neg.w   r3, r3
+
+        ldrsh.w r4, [r1, #4]
+        ldrsh.w r6, [r1, #6]
+        ldrsh.w r5, [r2, #4]
+        ldrsh.w r7, [r2, #6]
+
+        mul.w   r9, r6, r7
+        montgomerym3 r8, r14, r9, r10
+        mul.w   r9, r9, r3
+        mla.w   r9, r4, r5, r9
+        montgomerym3 r8, r14, r9, r10
+        strh.w  r9, [r0, #4]
+
+        mul.w   r9, r4, r7
+        mla.w   r9, r6, r5, r9
+        montgomerym3 r8, r14, r9, r10
+        strh.w  r9, [r0, #6]
+
+        pop.w   {r4-r11, pc}
+        ENDP
+
+; =============================================================================
+; doublebasemul_asm_acc_m3 : accumulating variant of doublebasemul_asm_m3
+; Register mapping (note qinv moves to r11 here):
+;   r0=rptr r1=aptr r2=bptr r3=zeta
+;   r4=poly0 r5=poly2 r6=poly1 r7=poly3
+;   r8=q r9=tmp r10=tmp2 r11=qinv r12=res0 r14=res1
+; =============================================================================
+        ALIGN   4
+        EXPORT  doublebasemul_asm_acc_m3
+doublebasemul_asm_acc_m3 PROC
+        push.w  {r4-r11, lr}
+
+        movw    r8,  #3329          ; q
+        movw    r11, #3327          ; qinv
+
+        ldrsh.w r4,  [r1, #0]
+        ldrsh.w r6,  [r1, #2]
+        ldrsh.w r5,  [r2, #0]
+        ldrsh.w r7,  [r2, #2]
+        ldrsh.w r12, [r0, #0]
+        ldrsh.w r14, [r0, #2]
+
+        mul.w   r9, r6, r7
+        montgomerym3 r8, r11, r9, r10
+        mul.w   r9, r9, r3
+        mla.w   r9, r4, r5, r9
+        montgomerym3 r8, r11, r9, r10
+        add.w   r12, r12, r9
+        strh.w  r12, [r0, #0]
+
+        mul.w   r9, r4, r7
+        mla.w   r9, r6, r5, r9
+        montgomerym3 r8, r11, r9, r10
+        add.w   r14, r14, r9
+        strh.w  r14, [r0, #2]
+
+        neg.w   r3, r3
+
+        ldrsh.w r4,  [r1, #4]
+        ldrsh.w r6,  [r1, #6]
+        ldrsh.w r5,  [r2, #4]
+        ldrsh.w r7,  [r2, #6]
+        ldrsh.w r12, [r0, #4]
+        ldrsh.w r14, [r0, #6]
+
+        mul.w   r9, r6, r7
+        montgomerym3 r8, r11, r9, r10
+        mul.w   r9, r9, r3
+        mla.w   r9, r4, r5, r9
+        montgomerym3 r8, r11, r9, r10
+        add.w   r12, r12, r9
+        strh.w  r12, [r0, #4]
+
+        mul.w   r9, r4, r7
+        mla.w   r9, r6, r5, r9
+        montgomerym3 r8, r11, r9, r10
+        add.w   r14, r14, r9
+        strh.w  r14, [r0, #6]
+
+        pop.w   {r4-r11, pc}
+        ENDP
+
+; =============================================================================
+; basemul_asm_m3 : 64-iteration loop over doublebasemul pattern with zetaptr
+; Register mapping:
+;   r0=rptr r1=aptr r2=bptr r3=zetaptr
+;   r4=poly0 r5=poly2 r6=poly1 r7=poly3
+;   r8=q r9=tmp r10=tmp2 r11=qinv r12=zeta r14=loop
+; =============================================================================
+        ALIGN   4
+        EXPORT  basemul_asm_m3
+basemul_asm_m3 PROC
+        push.w  {r4-r11, lr}
+
+        movw    r8,  #3329          ; q
+        movw    r11, #3327          ; qinv
+
+        movw    r14, #64            ; loop
+bmul_L1
+        ldrsh.w r12, [r3], #2       ; zeta
+
+        ldrsh.w r6, [r1,  #2]
+        ldrsh.w r4, [r1], #4
+        ldrsh.w r7, [r2,  #2]
+        ldrsh.w r5, [r2], #4
+
+        mul.w   r9, r6, r7
+        montgomerym3 r8, r11, r9, r10
+        mul.w   r9, r9, r12
+        mla.w   r9, r4, r5, r9
+        montgomerym3 r8, r11, r9, r10
+        strh.w  r9, [r0], #2
+
+        mul.w   r9, r4, r7
+        mla.w   r9, r6, r5, r9
+        montgomerym3 r8, r11, r9, r10
+        strh.w  r9, [r0], #2
+
+        neg.w   r12, r12
+
+        ldrsh.w r6, [r1,  #2]
+        ldrsh.w r4, [r1], #4
+        ldrsh.w r7, [r2,  #2]
+        ldrsh.w r5, [r2], #4
+
+        mul.w   r9, r6, r7
+        montgomerym3 r8, r11, r9, r10
+        mul.w   r9, r9, r12
+        mla.w   r9, r4, r5, r9
+        montgomerym3 r8, r11, r9, r10
+        strh.w  r9, [r0], #2
+
+        mul.w   r9, r4, r7
+        mla.w   r9, r6, r5, r9
+        montgomerym3 r8, r11, r9, r10
+        strh.w  r9, [r0], #2
+
+        subs.w  r14, #1
+        bne.w   bmul_L1
+
+        pop.w   {r4-r11, pc}
+        ENDP
+
+; =============================================================================
+; basemul_asm_acc_m3 : accumulating 64-iteration base-multiply
+; Same register mapping as basemul_asm_m3 above.
+; =============================================================================
+        ALIGN   4
+        EXPORT  basemul_asm_acc_m3
+basemul_asm_acc_m3 PROC
+        push.w  {r4-r11, lr}
+
+        movw    r8,  #3329          ; q
+        movw    r11, #3327          ; qinv
+
+        movw    r14, #64            ; loop
+bmul_acc_L1
+        ldrsh.w r12, [r3], #2       ; zeta
+
+        ldrsh.w r6, [r1,  #2]
+        ldrsh.w r4, [r1], #4
+        ldrsh.w r7, [r2,  #2]
+        ldrsh.w r5, [r2], #4
+
+        mul.w   r9, r6, r7
+        montgomerym3 r8, r11, r9, r10
+        mul.w   r9, r9, r12
+        mla.w   r9, r4, r5, r9
+        montgomerym3 r8, r11, r9, r10
+        ldrsh.w r10, [r0]
+        add.w   r9, r9, r10
+        strh.w  r9, [r0], #2
+
+        mul.w   r9, r4, r7
+        mla.w   r9, r6, r5, r9
+        montgomerym3 r8, r11, r9, r10
+        ldrsh.w r10, [r0]
+        add.w   r9, r9, r10
+        strh.w  r9, [r0], #2
+
+        neg.w   r12, r12
+
+        ldrsh.w r6, [r1,  #2]
+        ldrsh.w r4, [r1], #4
+        ldrsh.w r7, [r2,  #2]
+        ldrsh.w r5, [r2], #4
+
+        mul.w   r9, r6, r7
+        montgomerym3 r8, r11, r9, r10
+        mul.w   r9, r9, r12
+        mla.w   r9, r4, r5, r9
+        montgomerym3 r8, r11, r9, r10
+        ldrsh.w r10, [r0]
+        add.w   r9, r9, r10
+        strh.w  r9, [r0], #2
+
+        mul.w   r9, r4, r7
+        mla.w   r9, r6, r5, r9
+        montgomerym3 r8, r11, r9, r10
+        ldrsh.w r10, [r0]
+        add.w   r9, r9, r10
+        strh.w  r9, [r0], #2
+
+        subs.w  r14, #1
+        bne.w   bmul_acc_L1
+
+        pop.w   {r4-r11, pc}
+        ENDP
+
+        END


### PR DESCRIPTION
Convert the GNU-as Thumb-2 source from mupq/pqm3's
crypto_kem/kyber768/m3/kyberm3.S into armasm v5.06 syntax targeting
SC300 (Cortex-M3 / ARMv7-M). Instruction stream is preserved verbatim;
only directives, macro syntax, and register-alias handling have been
translated:

- .syntax unified / .thumb → PRESERVE8 / THUMB / AREA |.text|,CODE,READONLY
- .global + .type,%function → EXPORT + PROC/ENDP wrapper per function
- .macro/.endm → MACRO/MEND, with \arg rewritten to \$arg
- .align 2 (2^2=4 bytes) → ALIGN 4
- movw.w (r14/q/qinv) → MOVW (armasm rejects the redundant .w)
- .req/.unreq aliases inline-expanded to physical registers per function
- Numeric local labels (1:, bne 1b) → named labels (psub_L1, padd_L1,
  barred_L1, frommont_L1, bmul_L1, bmul_acc_L1)
- Comments converted to armasm semicolon form, file terminated with END

All eight exported symbols preserved: pointwise_sub_m3, pointwise_add_m3,
asm_barrett_reduce_m3, asm_frommont_m3, doublebasemul_asm_m3,
doublebasemul_asm_acc_m3, basemul_asm_m3, basemul_asm_acc_m3.